### PR TITLE
Some insight on the DxFlags

### DIFF
--- a/FtexTool/Ftex/FtexFile.cs
+++ b/FtexTool/Ftex/FtexFile.cs
@@ -39,6 +39,14 @@ namespace FtexTool.Ftex
         public short UnknownFlags { get; set; }
         // Flags
         // 1, 3, 7 ,9
+        // 1 - SRM/MTM files, Each channel acts as a material parameter
+        //      R = Ambient Occlusion
+        //      G = Specular Albedo
+        //      B = Roughness
+        // 3 - BSM files, Albedo diffuse textures
+        // 7 - CBM files, Cubemap files. In this case there are 6 times
+        //                  as many MIP entries for each face
+        // 9 - NRM files, Normal maps
         // 0x1 Always set
         // 0x2 
         // 0x4 Texturecube


### PR DESCRIPTION
The Int32 at 0x1c acts more as a "usage" flag from what I have been seeing. There are parts in the code that flip the endian of every field in the FTEX header and this region seems to be swapped as a full 32bit integer rather than two distinct shorts.
